### PR TITLE
Update abe.py

### DIFF
--- a/Abe/abe.py
+++ b/Abe/abe.py
@@ -1540,7 +1540,7 @@ class Abe:
                 elif fmt in ("json", "jsonp"):
                     ret.append([
                             height, int(nTime), target, avg_target,
-                            difficulty, work, chain_work, nethash])
+                            difficulty, work, interval_seconds / interval, nethash])
 
                 elif fmt == "svg":
                     ret += '<abe:nethash t="%d" d="%d"' \


### PR DESCRIPTION
In the description to the API explorer it is written that in the penultimate column should be avgIntervalSinceLast